### PR TITLE
Build robust oparl ingest service

### DIFF
--- a/backend/core/migrations/0006_oparl_nkeys_and_config.py
+++ b/backend/core/migrations/0006_oparl_nkeys_and_config.py
@@ -1,0 +1,165 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+	dependencies = [
+		("core", "0005_lead"),
+	]
+
+	operations = [
+		migrations.AddField(
+			model_name="organization",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="organization",
+			name="raw",
+			field=models.JSONField(default=dict),
+		),
+		migrations.AddField(
+			model_name="committee",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="committee",
+			name="raw",
+			field=models.JSONField(default=dict),
+		),
+		migrations.AddField(
+			model_name="person",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="person",
+			name="raw",
+			field=models.JSONField(default=dict),
+		),
+		migrations.AddField(
+			model_name="meeting",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="meeting",
+			name="raw",
+			field=models.JSONField(default=dict),
+		),
+		migrations.AddField(
+			model_name="agendaitem",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="agendaitem",
+			name="raw",
+			field=models.JSONField(default=dict),
+		),
+		migrations.AddField(
+			model_name="document",
+			name="source_base",
+			field=models.CharField(default="", blank=True, max_length=255, db_index=True),
+		),
+		migrations.AddField(
+			model_name="document",
+			name="mimetype",
+			field=models.CharField(default="", blank=True, max_length=100),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="team",
+			field=models.ForeignKey(null=True, blank=True, on_delete=models.deletion.CASCADE, to="core.team"),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="auth_type",
+			field=models.CharField(default="none", max_length=20, choices=[("none", "None"), ("api_key", "API Key"), ("basic", "Basic Auth")]),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="api_key_header",
+			field=models.CharField(default="Authorization", blank=True, max_length=100),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="api_key_value",
+			field=models.CharField(default="", blank=True, max_length=500),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="username",
+			field=models.CharField(default="", blank=True, max_length=200),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="password",
+			field=models.CharField(default="", blank=True, max_length=200),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="requests_per_minute",
+			field=models.PositiveIntegerField(default=60),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="max_parallel_requests",
+			field=models.PositiveIntegerField(default=4),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="request_timeout_seconds",
+			field=models.PositiveIntegerField(default=30),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="max_retries",
+			field=models.PositiveIntegerField(default=3),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_body",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_person",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_organization",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_meeting",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_agenda_item",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_paper",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="include_file",
+			field=models.BooleanField(default=True),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="cron",
+			field=models.CharField(default="", blank=True, max_length=100),
+		),
+		migrations.AddField(
+			model_name="oparlsource",
+			name="frequency_seconds",
+			field=models.PositiveIntegerField(default=0),
+		),
+	]

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -12,31 +12,58 @@ class TenantSerializer(serializers.ModelSerializer):
 class CommitteeSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Committee
-		fields = ["id", "tenant", "name", "oparl_id", "organization"]
+        fields = [
+            "id",
+            "tenant",
+            "name",
+            "oparl_id",
+            "organization",
+            "source_base",
+            "raw",
+        ]
 
 
 class PersonSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Person
-		fields = ["id", "tenant", "name", "party", "oparl_id"]
+        fields = ["id", "tenant", "name", "party", "oparl_id", "source_base", "raw"]
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Organization
-		fields = ["id", "tenant", "name", "oparl_id"]
+        fields = ["id", "tenant", "name", "oparl_id", "source_base", "raw"]
 
 
 class MeetingSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = Meeting
-		fields = ["id", "tenant", "committee", "start", "end", "oparl_id"]
+        fields = [
+            "id",
+            "tenant",
+            "committee",
+            "start",
+            "end",
+            "oparl_id",
+            "source_base",
+            "raw",
+        ]
 
 
 class AgendaItemSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = AgendaItem
-		fields = ["id", "tenant", "meeting", "position", "title", "category", "oparl_id"]
+        fields = [
+            "id",
+            "tenant",
+            "meeting",
+            "position",
+            "title",
+            "category",
+            "oparl_id",
+            "source_base",
+            "raw",
+        ]
 
 
 class DocumentSerializer(serializers.ModelSerializer):
@@ -53,6 +80,8 @@ class DocumentSerializer(serializers.ModelSerializer):
 			"content_text",
 			"content_hash",
 			"oparl_id",
+            "source_base",
+            "mimetype",
 			"created_at",
 			"updated_at",
 		]
@@ -85,5 +114,32 @@ class TeamMembershipSerializer(serializers.ModelSerializer):
 class OParlSourceSerializer(serializers.ModelSerializer):
 	class Meta:
 		model = OParlSource
-		fields = ["id", "tenant", "root_url", "enabled", "last_synced_at", "etag", "last_modified"]
+        fields = [
+            "id",
+            "tenant",
+            "team",
+            "root_url",
+            "enabled",
+            "last_synced_at",
+            "etag",
+            "last_modified",
+            "auth_type",
+            "api_key_header",
+            "api_key_value",
+            "username",
+            "password",
+            "requests_per_minute",
+            "max_parallel_requests",
+            "request_timeout_seconds",
+            "max_retries",
+            "include_body",
+            "include_person",
+            "include_organization",
+            "include_meeting",
+            "include_agenda_item",
+            "include_paper",
+            "include_file",
+            "cron",
+            "frequency_seconds",
+        ]
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -41,25 +41,55 @@ class CommitteeViewSet(BaseTenantViewSet):
 	queryset = Committee.objects.all()
 	serializer_class = CommitteeSerializer
 
+    def create(self, request, *args, **kwargs):
+        up = _upsert_create(self, Committee, request)
+        if up is not None:
+            return up
+        return super().create(request, *args, **kwargs)
+
 
 class PersonViewSet(BaseTenantViewSet):
 	queryset = Person.objects.all()
 	serializer_class = PersonSerializer
+
+    def create(self, request, *args, **kwargs):
+        up = _upsert_create(self, Person, request)
+        if up is not None:
+            return up
+        return super().create(request, *args, **kwargs)
 
 
 class OrganizationViewSet(BaseTenantViewSet):
 	queryset = Organization.objects.all()
 	serializer_class = OrganizationSerializer
 
+    def create(self, request, *args, **kwargs):
+        up = _upsert_create(self, Organization, request)
+        if up is not None:
+            return up
+        return super().create(request, *args, **kwargs)
+
 
 class MeetingViewSet(BaseTenantViewSet):
 	queryset = Meeting.objects.all().select_related("committee")
 	serializer_class = MeetingSerializer
 
+    def create(self, request, *args, **kwargs):
+        up = _upsert_create(self, Meeting, request)
+        if up is not None:
+            return up
+        return super().create(request, *args, **kwargs)
+
 
 class AgendaItemViewSet(BaseTenantViewSet):
 	queryset = AgendaItem.objects.all().select_related("meeting")
 	serializer_class = AgendaItemSerializer
+
+    def create(self, request, *args, **kwargs):
+        up = _upsert_create(self, AgendaItem, request)
+        if up is not None:
+            return up
+        return super().create(request, *args, **kwargs)
 
 
 class DocumentViewSet(BaseTenantViewSet):
@@ -67,14 +97,41 @@ class DocumentViewSet(BaseTenantViewSet):
 	serializer_class = DocumentSerializer
 
 	def create(self, request, *args, **kwargs):
-		content_hash = request.data.get("content_hash")
-		tenant_id = request.data.get("tenant")
-		if content_hash and tenant_id:
-			existing = Document.objects.filter(tenant_id=tenant_id, content_hash=content_hash).first()
-			if existing:
-				ser = self.get_serializer(existing)
-				return Response(ser.data, status=status.HTTP_200_OK)
-		return super().create(request, *args, **kwargs)
+        content_hash = request.data.get("content_hash")
+        tenant_id = request.data.get("tenant")
+        oparl_id = request.data.get("oparl_id")
+        source_base = request.data.get("source_base", "")
+        if content_hash and tenant_id:
+            existing = Document.objects.filter(tenant_id=tenant_id, content_hash=content_hash).first()
+            if existing:
+                ser = self.get_serializer(existing)
+                return Response(ser.data, status=status.HTTP_200_OK)
+        if tenant_id and oparl_id and source_base:
+            existing = Document.objects.filter(
+                tenant_id=tenant_id, oparl_id=oparl_id, source_base=source_base
+            ).first()
+            if existing:
+                serializer = self.get_serializer(existing, data=request.data, partial=True)
+                serializer.is_valid(raise_exception=True)
+                self.perform_update(serializer)
+                return Response(serializer.data, status=status.HTTP_200_OK)
+        return super().create(request, *args, **kwargs)
+
+
+def _upsert_create(viewset, model_cls, request):
+    tenant_id = request.data.get("tenant")
+    oparl_id = request.data.get("oparl_id")
+    source_base = request.data.get("source_base", "")
+    if tenant_id and oparl_id and source_base:
+        existing = model_cls.objects.filter(
+            tenant_id=tenant_id, oparl_id=oparl_id, source_base=source_base
+        ).first()
+        if existing:
+            serializer = viewset.get_serializer(existing, data=request.data, partial=True)
+            serializer.is_valid(raise_exception=True)
+            viewset.perform_update(serializer)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+    return None
 
 
 class MotionViewSet(BaseTenantViewSet):
@@ -110,7 +167,15 @@ class OParlSourceViewSet(BaseTenantViewSet):
 			source = self.get_object()
 			base = os.getenv("INGEST_BASE_URL", "http://ingest:8001")
 			with httpx.Client(timeout=30.0) as client:
-				r = client.post(f"{base}/oparl/ingest", params={"root": source.root_url, "tenant_id": source.tenant_id})
+				r = client.post(
+					f"{base}/oparl/ingest",
+					params={
+						"root": source.root_url,
+						"tenant_id": source.tenant_id,
+						"source_id": source.id,
+						"source_base": source.root_url,
+					},
+				)
 				return Response(r.json(), status=r.status_code)
 		except Exception as e:
 			return Response({"error": str(e)}, status=500)

--- a/services/ingest/app/main.py
+++ b/services/ingest/app/main.py
@@ -1,26 +1,47 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import io
 import json
-from typing import Any, Dict, Optional
+import mimetypes
+from typing import Any, Dict, Optional, Tuple
 
 import httpx
 from fastapi import FastAPI, HTTPException
 from pdfminer.high_level import extract_text
 
 app = FastAPI(title="Mandari Ingest Service")
+REQUEST_BACKOFF_BASE_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 30.0
 
 
 def sha256_bytes(data: bytes) -> str:
 	return hashlib.sha256(data).hexdigest()
 
 
-async def fetch_json(url: str) -> Dict[str, Any]:
-	async with httpx.AsyncClient(timeout=30.0) as client:
-		r = await client.get(url)
-		r.raise_for_status()
-		return r.json()
+async def fetch_json(url: str, headers: Optional[Dict[str, str]] = None, etag: Optional[str] = None, last_modified: Optional[str] = None, timeout: float = 30.0, max_retries: int = 3) -> Tuple[Optional[Dict[str, Any]], Dict[str, str]]:
+	req_headers = headers.copy() if headers else {}
+	if etag:
+		req_headers["If-None-Match"] = etag
+	if last_modified:
+		req_headers["If-Modified-Since"] = last_modified
+	attempt = 0
+	backoff = REQUEST_BACKOFF_BASE_SECONDS
+	async with httpx.AsyncClient(timeout=timeout) as client:
+		while True:
+			try:
+				r = await client.get(url, headers=req_headers)
+				if r.status_code == 304:
+					return None, {"etag": r.headers.get("ETag", ""), "last_modified": r.headers.get("Last-Modified", "")}
+				r.raise_for_status()
+				return r.json(), {"etag": r.headers.get("ETag", ""), "last_modified": r.headers.get("Last-Modified", "")}
+			except Exception:
+				attempt += 1
+				if attempt > max_retries:
+					raise
+				await asyncio.sleep(min(backoff, MAX_BACKOFF_SECONDS))
+				backoff *= 2
 
 
 @app.get("/health")
@@ -29,31 +50,42 @@ async def health() -> Dict[str, str]:
 
 
 @app.post("/oparl/ingest")
-async def ingest_oparl(root: str, tenant_id: int) -> Dict[str, Any]:
+async def ingest_oparl(root: str, tenant_id: int, source_id: Optional[int] = None, source_base: Optional[str] = None) -> Dict[str, Any]:
 	try:
-		catalog = await fetch_json(root)
+		catalog, cat_headers = await fetch_json(root)
 	except Exception as e:
 		raise HTTPException(status_code=400, detail=f"Katalog fehlerhaft: {e}")
 
-	# Minimaler Proof: lade bodies und meetings, schreibe über Backend-API
 	changes = {"organizations": 0, "meetings": 0, "documents": 0}
 	backend = "http://backend:8000/api"
 	async with httpx.AsyncClient(timeout=30.0) as client:
+		if source_id and (cat_headers.get("etag") or cat_headers.get("last_modified")):
+			try:
+				await client.patch(
+					f"{backend}/oparl-sources/{source_id}/",
+					json={
+						"etag": cat_headers.get("etag", ""),
+						"last_modified": cat_headers.get("last_modified", ""),
+					},
+				)
+			except Exception:
+				pass
 		for body_url in catalog.get("body", []):
-			body = await fetch_json(body_url)
+			body, _ = await fetch_json(body_url)
 			org = {
 				"tenant": tenant_id,
 				"name": body.get("name") or body.get("shortName", "Körperschaft"),
 				"oparl_id": body.get("id", body_url),
+				"source_base": source_base or root,
+				"raw": body,
 			}
 			await client.post(f"{backend}/organizations/", json=org)
 			changes["organizations"] += 1
 
 		meetings_list = catalog.get("meeting", [])
 		for m_url in meetings_list:
-			meeting = await fetch_json(m_url)
+			meeting, _ = await fetch_json(m_url)
 			committee_name = (meeting.get("committee") or {}).get("name", "Ausschuss") if isinstance(meeting.get("committee"), dict) else "Ausschuss"
-			# Upsert Committee by name (idempotent Demo)
 			r = await client.get(f"{backend}/committees/?tenant={tenant_id}")
 			committee_id: Optional[int] = None
 			for c in r.json():
@@ -72,18 +104,22 @@ async def ingest_oparl(root: str, tenant_id: int) -> Dict[str, Any]:
 					"committee": committee_id,
 					"start": start,
 					"oparl_id": meeting.get("id", m_url),
+					"source_base": source_base or root,
+					"raw": meeting,
 				},
 			)
 			meeting_id = mr.json()["id"]
 			changes["meetings"] += 1
 
-			# Documents: fetch files if linked as URL in meeting
 			for f_url in meeting.get("auxiliaryFile", []):
 				try:
 					fr = await client.get(f_url)
 					fr.raise_for_status()
 					content = fr.content
 					content_hash = sha256_bytes(content)
+					mime, _ = mimetypes.guess_type(f_url)
+					if not mime:
+						mime = fr.headers.get("Content-Type", "application/octet-stream").split(";")[0]
 					try:
 						text = extract_text(io.BytesIO(content))
 					except Exception:
@@ -98,6 +134,8 @@ async def ingest_oparl(root: str, tenant_id: int) -> Dict[str, Any]:
 							"content_text": text[:10000],
 							"content_hash": content_hash,
 							"oparl_id": f_url,
+							"source_base": source_base or root,
+							"mimetype": mime,
 						},
 					)
 					changes["documents"] += 1


### PR DESCRIPTION
Implement multi-endpoint OParl ingest with configurable sources, idempotency via natural keys, and enhanced resilience.

This PR establishes the foundational data model and initial ingest logic to support multiple OParl instances, ensuring data integrity through upserts based on natural keys (`oparl_id`, `source_base`) and enabling efficient delta updates using HTTP headers (ETag, Last-Modified). It also prepares for configurable authentication, rate limits, resource selection, and scheduling per OParl source.

---
<a href="https://cursor.com/background-agent?bcId=bc-6feae9cb-4461-4ea2-ac7a-4613daf242e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6feae9cb-4461-4ea2-ac7a-4613daf242e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

